### PR TITLE
fix generateGridWidgetObject method

### DIFF
--- a/BlazorGridStack/wwwroot/gridStackInterop.js
+++ b/BlazorGridStack/wwwroot/gridStackInterop.js
@@ -147,7 +147,7 @@ function generateGridWidgetObject(widget)
             w: widget.w,
             content: widget.el? widget.el.innerHTML : null,
             className: widget.el? widget.el.className : null,
-            id: widget.id
+            id: widget.el.id
         }
 }
 


### PR DESCRIPTION
generateGridWidgetObject return null ids.
It seems that element ids should be returned.